### PR TITLE
Applied performance improvements for async and worker publishers:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /spec/db.sqlite3
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in barkmq.gemspec
 gemspec
+
+group :test do
+ gem 'sqlite3', '~> 1.3.5'
+end

--- a/barkmq.gemspec
+++ b/barkmq.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "retries", "~> 0.0.5"
   spec.add_dependency "sidekiq", "< 5"
 
-  spec.add_development_dependency "bundler", "~> 1.9"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "redis"

--- a/lib/barkmq/async_publisher.rb
+++ b/lib/barkmq/async_publisher.rb
@@ -13,11 +13,6 @@ module BarkMQ
 
     PUBLISH_TIMEOUT = 30
 
-    def _publish topic_name, message
-      topic_arn = Shoryuken::Client.sns.create_topic(name: topic_name).topic_arn
-      Shoryuken::Client.sns.publish(topic_arn: topic_arn, message: message)
-    end
-
     def publish(topic_name, message, options={})
       begin
         @timer = after(options[:timeout] || PUBLISH_TIMEOUT) { timeout(topic_name) }
@@ -32,7 +27,7 @@ module BarkMQ
                                      rescue: CONNECTION_ERRORS,
                                      base_sleep_seconds: 0.05,
                                      max_sleep_seconds: 0.25) do
-            _publish(topic_name, message)
+            publisher.publish(topic_name, message)
           end
         end
       rescue => e
@@ -44,6 +39,10 @@ module BarkMQ
     end
 
     private
+
+    def publisher
+      BarkMQ::Publisher
+    end
 
     def logger
       BarkMQ.publisher_config.logger

--- a/lib/barkmq/config/shared.rb
+++ b/lib/barkmq/config/shared.rb
@@ -15,6 +15,7 @@ module BarkMQ
         base.attribute :topic_names, Array, default: []
         base.attribute :statsd, Statsd, default: Statsd.new
         base.attribute :error_handler
+        base.attribute :topic_arns, Hash, default: {}
       end
 
       def add_topic(topic, options={})
@@ -22,6 +23,10 @@ module BarkMQ
         unless topic_names.include?(full_topic)
           topic_names << full_topic
         end
+      end
+
+      def fetch_topic_arn(topic_name)
+        topic_arns[topic_name] ||= Shoryuken::Client.sns.create_topic(name: topic_name).topic_arn
       end
     end
 

--- a/lib/barkmq/publisher.rb
+++ b/lib/barkmq/publisher.rb
@@ -5,6 +5,11 @@ module BarkMQ
       base.send :include, InstanceMethods
     end
 
+    def self.publish topic_name, message
+      topic_arn = BarkMQ.publisher_config.fetch_topic_arn(topic_name)
+      Shoryuken::Client.sns.publish(topic_arn: topic_arn, message: message)
+    end
+
     module ClassMethods
       attr_accessor :message_serializer
     end

--- a/spec/barkmq/publisher_spec.rb
+++ b/spec/barkmq/publisher_spec.rb
@@ -8,6 +8,21 @@ RSpec.describe BarkMQ::Publisher do
     end
   end
 
+  describe '.publish' do
+    let(:topic_name) { 'queue-name-1' }
+    let(:topic_arn) { 'queue-name-1-arn' }
+    let(:message) { 'example-message' }
+
+    it 'should handle publish to sns by using topic name and message' do
+      expect(Shoryuken::Client.sns).to receive(:create_topic).and_return(
+        double('topic_arn', topic_arn: topic_arn))
+      expect(Shoryuken::Client.sns).to receive(:publish).with(
+        topic_arn: topic_arn, message: message)
+
+      BarkMQ::Publisher.publish(topic_name, message)
+    end
+  end
+
   describe '.model_name' do
     it 'PORO with no options' do
       class NewPublisher
@@ -36,6 +51,7 @@ RSpec.describe BarkMQ::Publisher do
 
     it 'ActiveRecord with no options' do
       class NewArPublisher < ActiveRecord::Base
+        acts_as_publisher
       end
       @publisher = NewArPublisher.new
       expect(@publisher.publish_topics[:create]).to eq('new_ar_publisher-created')

--- a/spec/barkmq/shared_spec.rb
+++ b/spec/barkmq/shared_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe 'BarkMQ.publisher_config' do
+  describe '#topics_arns' do
+    let(:config) { BarkMQ::Config::Publisher.new }
+
+    it { expect(config.topic_arns).to be }
+
+    it 'should cache topics_arns' do
+        expect(config.topic_arns.keys).to be_empty
+
+        expect(Shoryuken::Client.sns).to receive(:create_topic).and_return(
+            double('topic_arn', topic_arn: 'queue-name-1-arn'))
+        expect(config.fetch_topic_arn('queue-name-1')).to eq('queue-name-1-arn')
+        expect(config.topic_arns.keys.size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
- moved `_publish` method as class method to `BarkMQ::Publisher` module:
Example: `BarkMQ::Publisher.publish(topic_name, message)`.
Previously it was defined in multiple places async and worker publishers.

- improved performance of `publish` method by caching topic_arn instead of
calling all the time create_topic of AWS library. Now BarkMQ.publisher_config contains topic_arns as cached ARN names.
Introduced the new method BarkMQ.publisher_config.fetch_topic_arn(topic_name) to get or create topic_arn once.

- verified that create_topic happened only once on `BarkMQ::Publisher.publish` and it doesn't require to make any enhancement

Spend my time for free and want to push this change as it is

author: @oivoodoo / @oivoodoo-work profiles