### PR TITLE
Fix SNS Regression

### DIFF
--- a/barkmq.gemspec
+++ b/barkmq.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dogstatsd-ruby", "~> 3.3.0"
   spec.add_dependency "shoryuken", "< 6"
   spec.add_dependency "aws-sdk-sqs"
+  spec.add_dependency "aws-sdk-sns"
   spec.add_dependency "celluloid", "~> 0.17.3"
   spec.add_dependency "retries", "~> 0.0.5"
   spec.add_dependency "sidekiq", "< 6"

--- a/lib/barkmq.rb
+++ b/lib/barkmq.rb
@@ -83,5 +83,9 @@ module BarkMQ
       end
     end
 
+    def sns_client
+      @sns_client ||= AWS::SNS::Client.new
+    end
+
   end
 end

--- a/lib/barkmq/async_publisher.rb
+++ b/lib/barkmq/async_publisher.rb
@@ -14,8 +14,8 @@ module BarkMQ
     PUBLISH_TIMEOUT = 30
 
     def _publish topic_name, message
-      topic_arn = Shoryuken::Client.sns.create_topic(name: topic_name).topic_arn
-      Shoryuken::Client.sns.publish(topic_arn: topic_arn, message: message)
+      topic_arn = BarkMQ.sns_client.create_topic(name: topic_name).topic_arn
+      BarkMQ.sns_client.publish(topic_arn: topic_arn, message: message)
     end
 
     def publish(topic_name, message, options={})

--- a/lib/barkmq/publisher_worker.rb
+++ b/lib/barkmq/publisher_worker.rb
@@ -13,8 +13,8 @@ module BarkMQ
     ].freeze
 
     def _publish topic_name, message
-      topic_arn = Shoryuken::Client.sns.create_topic(name: topic_name).topic_arn
-      Shoryuken::Client.sns.publish(topic_arn: topic_arn, message: message)
+      topic_arn = BarkMQ.sns_client.create_topic(name: topic_name).topic_arn
+      BarkMQ.sns_client.publish(topic_arn: topic_arn, message: message)
     end
 
     def perform(topic_name, message, options={})


### PR DESCRIPTION
Updates BarkMQ to use its own SNS client instance, as Shoryuken no longer provides one.