### PR TITLE
Update BarkMQ for Sidekiq 6 and Rails 6

### DIFF
--- a/barkmq.gemspec
+++ b/barkmq.gemspec
@@ -32,13 +32,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "shoryuken", "~> 2.0.4"
   spec.add_dependency "celluloid", "~> 0.17.3"
   spec.add_dependency "retries", "~> 0.0.5"
-  spec.add_dependency "sidekiq", "< 6"
+  spec.add_dependency "sidekiq", "< 7"
 
-  spec.add_development_dependency "bundler", "~> 1.9"
+  spec.add_development_dependency "bundler", "< 3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "redis"
-  spec.add_development_dependency "activerecord", "~> 3.0"
+  spec.add_development_dependency "activerecord", "< 7"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "coveralls"
 

--- a/lib/barkmq/acts_as_publisher.rb
+++ b/lib/barkmq/acts_as_publisher.rb
@@ -18,9 +18,9 @@ module BarkMQ
         options[:on] ||= [ :create, :update, :destroy ]
         options[:on] = Array(options[:on])
 
-        options[:create_topic] ||= [ self.model_name.param_key, 'created' ].join('-')
-        options[:update_topic] ||= [ self.model_name.param_key, 'updated' ].join('-')
-        options[:destroy_topic] ||= [ self.model_name.param_key, 'destroyed' ].join('-')
+        options[:create_topic] ||= [ self.bark_mq_model_name, 'created' ].join('-')
+        options[:update_topic] ||= [ self.bark_mq_model_name, 'updated' ].join('-')
+        options[:destroy_topic] ||= [ self.bark_mq_model_name, 'destroyed' ].join('-')
 
         self.publish_topics[:create] ||= options[:create_topic]
         self.publish_topics[:update] ||= options[:update_topic]

--- a/lib/barkmq/publisher.rb
+++ b/lib/barkmq/publisher.rb
@@ -10,8 +10,7 @@ module BarkMQ
     end
 
     module InstanceMethods
-
-      def model_name
+      def bark_mq_model_name
         if self.class.ancestors.include?(ActiveRecord::Base)
           self.class.model_name.param_key
         else

--- a/spec/barkmq/acts_as_publisher_spec.rb
+++ b/spec/barkmq/acts_as_publisher_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe BarkMQ::ActsAsPublisher do
       @publisher_record = NewArPublisher.new
       expect(@publisher_record).to receive(:after_create_publish).and_call_original
       expect(@publisher_record).to receive(:publish_to_sns)
+      expect(@publisher_record).to receive(:run_publish_callbacks).with(:after_publish_on_complete)
       expect(@publisher_record).to receive(:run_publish_callbacks).with(:after_publish_on_create)
       @publisher_record.save!
     end
@@ -102,6 +103,7 @@ RSpec.describe BarkMQ::ActsAsPublisher do
       @publisher_record = NewArPublisher.create!
       expect(@publisher_record).to receive(:after_update_publish).and_call_original
       expect(@publisher_record).to receive(:publish_to_sns)
+      expect(@publisher_record).to receive(:run_publish_callbacks).with(:after_publish_on_complete)
       expect(@publisher_record).to receive(:run_publish_callbacks).with(:after_publish_on_update)
       @publisher_record.event = 'update'
       @publisher_record.save!
@@ -118,6 +120,7 @@ RSpec.describe BarkMQ::ActsAsPublisher do
       @publisher_record = NewArPublisher.create!
       expect(@publisher_record).to receive(:after_destroy_publish).and_call_original
       expect(@publisher_record).to receive(:publish_to_sns)
+      expect(@publisher_record).to receive(:run_publish_callbacks).with(:after_publish_on_complete)
       expect(@publisher_record).to receive(:run_publish_callbacks).with(:after_publish_on_destroy)
       @publisher_record.destroy
     end

--- a/spec/barkmq/handlers/default_error_spec.rb
+++ b/spec/barkmq/handlers/default_error_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe BarkMQ::Handlers::DefaultError do
   subject { described_class.new(options) }
 
-  let(:statsd) { Statsd.new }
+  let(:statsd) { BarkMQ::Statsd.new }
 
   describe '#call' do
     def call

--- a/spec/barkmq/middleware/datadog_publisher_logger_spec.rb
+++ b/spec/barkmq/middleware/datadog_publisher_logger_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe BarkMQ::Middleware::DatadogPublisherLogger do
   subject { described_class.new(options) }
 
-  let(:statsd) { Statsd.new }
+  let(:statsd) { BarkMQ::Statsd.new }
 
   describe '#call' do
     def call

--- a/spec/barkmq/publisher_spec.rb
+++ b/spec/barkmq/publisher_spec.rb
@@ -8,20 +8,21 @@ RSpec.describe BarkMQ::Publisher do
     end
   end
 
-  describe '.model_name' do
+  describe '.bark_mq_model_name' do
     it 'PORO with no options' do
       class NewPublisher
         include BarkMQ::Publisher
       end
-      @publisher = NewPublisher.new
-      expect(@publisher.model_name).to eq(nil)
+      publisher = NewPublisher.new
+      expect(publisher.bark_mq_model_name).to eq(nil)
     end
 
     it 'ActiveRecord with no options' do
       class NewArPublisher < ActiveRecord::Base
+        include BarkMQ::Publisher
       end
-      @publisher = NewArPublisher.new
-      expect(@publisher.model_name).to eq('new_ar_publisher')
+      publisher = NewArPublisher.new
+      expect(publisher.bark_mq_model_name).to eq('new_ar_publisher')
     end
   end
 
@@ -30,16 +31,16 @@ RSpec.describe BarkMQ::Publisher do
       class NewPublisher
         include BarkMQ::Publisher
       end
-      @publisher = NewPublisher.new
-      expect(@publisher.full_topic('created')).to eq('test-barkmq-created')
+      publisher = NewPublisher.new
+      expect(publisher.full_topic('created')).to eq('test-barkmq-created')
     end
 
     it 'ActiveRecord with no options' do
       class NewArPublisher < ActiveRecord::Base
       end
-      @publisher = NewArPublisher.new
-      expect(@publisher.publish_topics[:create]).to eq('new_ar_publisher-created')
-      expect(@publisher.full_topic(@publisher.publish_topics[:create])).to eq('test-barkmq-new_ar_publisher-created')
+      publisher = NewArPublisher.new
+      expect(publisher.publish_topics[:create]).to eq('new_ar_publisher-created')
+      expect(publisher.full_topic(publisher.publish_topics[:create])).to eq('test-barkmq-new_ar_publisher-created')
     end
   end
 
@@ -52,9 +53,9 @@ RSpec.describe BarkMQ::Publisher do
           { id: 1, message: 'test' }
         end
       end
-      @publisher = NewPublisher.new
+      publisher = NewPublisher.new
       expect(BarkMQ).to receive(:publish).with('test-barkmq-tested', { id: 1, message: 'test' }.to_json, { sync: true })
-      @publisher.publish_to_sns('tested')
+      publisher.publish_to_sns('tested')
     end
   end
 


### PR DESCRIPTION
Also fixes specs and the `#model_name` method, which was attempting to override a native ActiveModel method